### PR TITLE
make parent chainable, permissions not necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factoryfour/task-helper",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Helper classes for task output and datapoints",
   "engines": {
     "node": "6.10.0"

--- a/resources/datapoint.js
+++ b/resources/datapoint.js
@@ -136,6 +136,7 @@ class Datapoint {
 	// Set the parent
 	setParent(parent) {
 		this.body.parent = parent;
+		return this;
 	}
 
 	// Set custom permissions
@@ -181,7 +182,7 @@ class Datapoint {
 	// Check that all fields have been set, and if so, return JSON of data
 	generate() {
 		const myBody = this.body;
-		['type', 'format', 'content', 'parent', 'permissions'].forEach((fieldName) => {
+		['type', 'format', 'content', 'parent'].forEach((fieldName) => {
 			if (!myBody[fieldName]) {
 				throw Error(`Missing a field: ${fieldName}`);
 			}


### PR DESCRIPTION
small changes:

- make setParent() chainable
- `permissions` not necessary for Datapoint.generate()